### PR TITLE
fix excessive downscaling of portrait images in editor

### DIFF
--- a/src/com/android/gallery3d/filtershow/FilterShowActivity.java
+++ b/src/com/android/gallery3d/filtershow/FilterShowActivity.java
@@ -742,10 +742,15 @@ public class FilterShowActivity extends FragmentActivity implements OnItemClickL
             PrimaryImage primary = PrimaryImage.getImage();
             Rect originalBounds = primary.getOriginalBounds();
             if (primary.supportsHighRes()) {
-                int highresPreviewSize = primary.getOriginalBitmapLarge().getWidth() * 2;
-                if (highresPreviewSize > originalBounds.width()) {
-                    highresPreviewSize = originalBounds.width();
-                }
+                Bitmap originalBitmapLarge = primary.getOriginalBitmapLarge();
+                Rect highresPreviewRect = new Rect(0, 0, originalBitmapLarge.getWidth(), originalBitmapLarge.getHeight());
+                // Make sure that 'highresPreviewRect' is not larger than 'originalBounds'.
+                highresPreviewRect.intersect(originalBounds);
+                // The 'loadOrientedConstrainedBitmap' function scales down the image based on its
+                // larger dimension (either width or height). To prevent excessive downscaling,
+                // 'highresPreviewSize' must be set in accordance with the dimension that is larger,
+                // either width or height.
+                int highresPreviewSize = Math.max(highresPreviewRect.width(), highresPreviewRect.height());
                 Rect bounds = new Rect();
                 Bitmap originalHires = ImageLoader.loadOrientedConstrainedBitmap(primary.getUri(),
                         primary.getActivity(), highresPreviewSize,

--- a/src/com/android/gallery3d/filtershow/imageshow/PrimaryImage.java
+++ b/src/com/android/gallery3d/filtershow/imageshow/PrimaryImage.java
@@ -53,8 +53,8 @@ public class PrimaryImage implements RenderingRequestCaller {
     private static final String LOGTAG = "PrimaryImage";
     private boolean DEBUG  = false;
     private static final boolean DISABLEZOOM = false;
-    public static final int SMALL_BITMAP_DIM = 160;
-    public static final int MAX_BITMAP_DIM = 900;
+    public static final int SMALL_BITMAP_DIM = 320;
+    public static final int MAX_BITMAP_DIM = 1800;
     private static PrimaryImage sPrimaryImage = null;
 
     private boolean mSupportsHighRes = false;


### PR DESCRIPTION
The 'loadOrientedConstrainedBitmap' function scales down the image based on its larger dimension (either width or height). To prevent excessive downscaling, 'highresPreviewSize' must be set in accordance with the dimension that is larger, either width or height.