### PR TITLE
remove the Delete option for items that represent multiple images

### DIFF
--- a/src/com/android/gallery3d/data/ClusterAlbum.java
+++ b/src/com/android/gallery3d/data/ClusterAlbum.java
@@ -120,7 +120,7 @@ public class ClusterAlbum extends MediaSet implements ContentListener {
 
     @Override
     public int getSupportedOperations() {
-        return SUPPORT_SHARE | SUPPORT_DELETE | SUPPORT_INFO;
+        return SUPPORT_SHARE | SUPPORT_INFO;
     }
 
     @Override

--- a/src/com/android/gallery3d/data/FilterTypeSet.java
+++ b/src/com/android/gallery3d/data/FilterTypeSet.java
@@ -119,7 +119,7 @@ public class FilterTypeSet extends MediaSet implements ContentListener {
 
     @Override
     public int getSupportedOperations() {
-        return SUPPORT_SHARE | SUPPORT_DELETE;
+        return SUPPORT_SHARE;
     }
 
     @Override

--- a/src/com/android/gallery3d/data/LocalAlbum.java
+++ b/src/com/android/gallery3d/data/LocalAlbum.java
@@ -266,7 +266,7 @@ public class LocalAlbum extends MediaSet {
 
     @Override
     public int getSupportedOperations() {
-        return SUPPORT_DELETE | SUPPORT_SHARE | SUPPORT_INFO;
+        return SUPPORT_SHARE | SUPPORT_INFO;
     }
 
     @Override


### PR DESCRIPTION
It's too easy to accidentally delete a large number of images via this option.

This change applies to albums and location/time/people/tag clusters. It doesn't apply to individual images and to multi-selection of individual images.